### PR TITLE
[Frontend] payment CRUD 기능을 구현했습니다

### DIFF
--- a/frontend/src/api/commonAPI.js
+++ b/frontend/src/api/commonAPI.js
@@ -5,15 +5,6 @@ class CommonAPI {
     this.baseURL = 'http://localhost:3000';
     this.abortController = new AbortController();
   }
-  beforeRequest = async (cb) => {
-    const token = localStorage.getItem('accessToken');
-    if (!token) {
-      await cb();
-      return;
-    }
-
-    const newAccessTokenResult = await this.getNewAccessToken();
-  };
 
   getNewAccessToken = async () => {};
 

--- a/frontend/src/api/paymentAPI.js
+++ b/frontend/src/api/paymentAPI.js
@@ -33,6 +33,20 @@ class PaymentAPI extends CommonAPI {
     const result = await this.request({ path, options });
     return result;
   };
+
+  deletePayment = async (paymentId) => {
+    const accessToken = this.getAccessToken();
+    const path = '/api/payment/' + paymentId;
+    const options = {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + accessToken,
+      },
+    };
+    const result = await this.request({ path, options });
+    return result;
+  };
 }
 
 export default new PaymentAPI();

--- a/frontend/src/api/paymentAPI.js
+++ b/frontend/src/api/paymentAPI.js
@@ -1,0 +1,38 @@
+import CommonAPI from './commonAPI.js';
+
+class PaymentAPI extends CommonAPI {
+  constructor() {
+    super();
+  }
+  getPayments = async () => {
+    const accessToken = this.getAccessToken();
+
+    const path = '/api/payment';
+    const options = {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + accessToken,
+      },
+    };
+    const result = await this.request({ path, options });
+    return result;
+  };
+
+  addPayment = async (name) => {
+    const accessToken = this.getAccessToken();
+    const path = '/api/payment';
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + accessToken,
+      },
+      body: JSON.stringify({ name }),
+    };
+    const result = await this.request({ path, options });
+    return result;
+  };
+}
+
+export default new PaymentAPI();

--- a/frontend/src/api/paymentAPI.js
+++ b/frontend/src/api/paymentAPI.js
@@ -47,6 +47,21 @@ class PaymentAPI extends CommonAPI {
     const result = await this.request({ path, options });
     return result;
   };
+
+  updatePayment = async ({ paymentId, name }) => {
+    const accessToken = this.getAccessToken();
+    const path = '/api/payment/' + paymentId;
+    const options = {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + accessToken,
+      },
+      body: JSON.stringify({ name }),
+    };
+    const result = await this.request({ path, options });
+    return result;
+  };
 }
 
 export default new PaymentAPI();

--- a/frontend/src/common/utils/error.js
+++ b/frontend/src/common/utils/error.js
@@ -4,5 +4,6 @@ const errorTypes = {
   LoginFailed: 'loginFailed',
   TokenExpired: 'tokenExpired',
   UnValidToken: 'unvalidToken',
+  NotExist: 'notExist',
 };
 export default errorTypes;

--- a/frontend/src/common/utils/notifyTypes.js
+++ b/frontend/src/common/utils/notifyTypes.js
@@ -12,6 +12,7 @@ const notifyTypes = {
   CLICK_GITHUB_OAUTH: 'click-github-oauth',
   FETCHED_GITHUB_AUTH_URL: 'fetched-github-auth-url',
   CLICK_ADD_PAYMENT: 'click-add-payment',
+  CLICK_EDIT_PAYMENT: 'click-edit-payment',
   CLOSE_MODAL: 'close-modal',
 };
 

--- a/frontend/src/common/utils/notifyTypes.js
+++ b/frontend/src/common/utils/notifyTypes.js
@@ -11,6 +11,8 @@ const notifyTypes = {
   LOGOUT: 'logout',
   CLICK_GITHUB_OAUTH: 'click-github-oauth',
   FETCHED_GITHUB_AUTH_URL: 'fetched-github-auth-url',
+  CLICK_ADD_PAYMENT: 'click-add-payment',
+  CLOSE_MODAL: 'close-modal',
 };
 
 export default notifyTypes;

--- a/frontend/src/models/userModel.js
+++ b/frontend/src/models/userModel.js
@@ -1,4 +1,5 @@
 import authAPI from '../api/authAPI.js';
+import paymentAPI from '../api/paymentAPI.js';
 
 import observer from '@/common/utils/observer';
 import notifyTypes from '../common/utils/notifyTypes';
@@ -10,6 +11,7 @@ class UserModel {
     this.isLogin = null;
     this.observer = observer;
     this.authAPI = authAPI;
+    this.payments = [];
     this.init();
   }
 
@@ -23,6 +25,12 @@ class UserModel {
         window.history.pushState({}, document.title, newUrl);
       }
     }
+
+    if (this.isLogin) {
+      this.payments = await this._fetchPayments();
+      console.log(this.payments);
+    }
+
     this.observer.notify(notifyTypes.INIT_USER, this.isLogin);
     this.observer.subscribe(
       notifyTypes.CLICK_GITHUB_OAUTH,
@@ -30,6 +38,14 @@ class UserModel {
       this.getGithubLoginURL
     );
     this.observer.subscribe(notifyTypes.CLICK_LOGOUT, this, this.logout);
+  };
+
+  _fetchPayments = async () => {
+    const result = await paymentAPI.getPayments();
+    if (result.success) {
+      return result.data;
+    }
+    return [];
   };
 
   checkLogin = async () => {
@@ -69,6 +85,15 @@ class UserModel {
 
   getIsLogin = () => {
     return this.isLogin;
+  };
+
+  getPayments = () => {
+    return this.payments;
+  };
+
+  addPayment = async (name) => {
+    const result = await paymentAPI.addPayment(name);
+    return result;
   };
 }
 

--- a/frontend/src/models/userModel.js
+++ b/frontend/src/models/userModel.js
@@ -101,6 +101,13 @@ class UserModel {
     this.observer.notify(notifyTypes.INIT_USER, this.isLogin);
     return result;
   };
+
+  deletePayment = async (paymentId) => {
+    const result = await paymentAPI.deletePayment(paymentId);
+    await this.setPayments();
+    this.observer.notify(notifyTypes.INIT_USER, this.isLogin);
+    return result;
+  };
 }
 
 export default new UserModel();

--- a/frontend/src/models/userModel.js
+++ b/frontend/src/models/userModel.js
@@ -27,8 +27,7 @@ class UserModel {
     }
 
     if (this.isLogin) {
-      this.payments = await this._fetchPayments();
-      console.log(this.payments);
+      await this.setPayments();
     }
 
     this.observer.notify(notifyTypes.INIT_USER, this.isLogin);
@@ -91,8 +90,15 @@ class UserModel {
     return this.payments;
   };
 
+  setPayments = async () => {
+    const result = await this._fetchPayments();
+    this.payments = result;
+  };
+
   addPayment = async (name) => {
     const result = await paymentAPI.addPayment(name);
+    await this.setPayments();
+    this.observer.notify(notifyTypes.INIT_USER, this.isLogin);
     return result;
   };
 }

--- a/frontend/src/models/userModel.js
+++ b/frontend/src/models/userModel.js
@@ -108,6 +108,13 @@ class UserModel {
     this.observer.notify(notifyTypes.INIT_USER, this.isLogin);
     return result;
   };
+
+  updatePayment = async ({ paymentId, name }) => {
+    const result = await paymentAPI.updatePayment({ paymentId, name });
+    await this.setPayments();
+    this.observer.notify(notifyTypes.INIT_USER, this.isLogin);
+    return result;
+  };
 }
 
 export default new UserModel();

--- a/frontend/src/views/components/auth/index.js
+++ b/frontend/src/views/components/auth/index.js
@@ -54,6 +54,7 @@ class Auth extends HTMLElement {
     this.setHTML(``);
     const $loginContainer = new Modal({
       $contentElement: this.$currentContent,
+      toggleModal: false,
     });
 
     this.appendChild($loginContainer);

--- a/frontend/src/views/components/auth/style.css
+++ b/frontend/src/views/components/auth/style.css
@@ -6,6 +6,7 @@
   justify-content: center;
   align-items: center;
   padding: 20px;
+  border-radius: 10px;
 }
 
 .auth-content h1 {
@@ -93,4 +94,5 @@
   font: var(--bold-small);
   color: var(--error);
   margin-top: 0.5em;
+  text-align: center;
 }

--- a/frontend/src/views/components/historyContainer/addPayment.js
+++ b/frontend/src/views/components/historyContainer/addPayment.js
@@ -1,0 +1,81 @@
+import HistoryPanel from './historyPanel'; // this can use history-statistics tag in inner html
+import HistoryContent from './historyContent'; // this can use history-content tag in inner html
+import historyStatistics from './historyStatistics';
+import observer from '@/common/utils/observer';
+import historyContainerController from './controller';
+
+import './style.css';
+import notifyTypes from '@/common/utils/notifyTypes';
+
+class AddPayment extends HTMLElement {
+  constructor() {
+    super();
+    this.controller = historyContainerController;
+    this.observer = observer;
+    this.controller.init();
+  }
+
+  connectedCallback() {
+    this.render();
+  }
+
+  addEvents = () => {
+    const $form = this.querySelector('#add-payment-form');
+    const $cancelBtn = this.querySelector('#cancel-btn');
+
+    $form.addEventListener('submit', this.handleSubmit);
+    $cancelBtn.addEventListener('click', () => {
+      this.observer.notify(notifyTypes.CLOSE_MODAL);
+    });
+  };
+
+  handleSubmit = async (event) => {
+    event.preventDefault();
+    const $payment = event.currentTarget.querySelector('#payment-input');
+    const name = $payment.value;
+    const result = await this.controller.addPayment(name);
+    if (!result.success) {
+      this.displayResultMessage(result.message, result.success);
+      return;
+    }
+    this.displayResultMessage('결제정보를 추가했습니다!', result.success);
+  };
+  displayResultMessage = (message, success) => {
+    const $addForm = this.querySelector('#add-payment-form');
+    const $errorText = $addForm.parentNode.querySelector('.error-text');
+    $errorText.innerText = message;
+    if (success) {
+      $errorText.style.color = 'var(--primary1)';
+    }
+    $errorText.style.display = 'block';
+  };
+  render = () => {
+    this.setHTML(
+      /*html*/ ` 
+      <form id='add-payment-form'>
+        <div class="top">
+            <label>
+                추가하실 결제수단을 적어주세요.
+            </label>
+            <input type='text' id='payment-input' placeholder="입력하세요"/>
+        </div>
+        <span class="error-text"></span>
+        <div class='bottom'>
+            <div class='left'>
+                <button id='cancel-btn' type='button'>취소</button>
+            </div>
+            <div>
+                <button id='submit-btn' type='submit'>등록</button>
+            </div>
+        </div>
+    </form>
+    `
+    ).addClass('add-payment');
+
+    this.addEvents();
+  };
+}
+
+customElements.define('add-payment', AddPayment);
+
+export default customElements.get('add-payment');

--- a/frontend/src/views/components/historyContainer/controller.js
+++ b/frontend/src/views/components/historyContainer/controller.js
@@ -95,6 +95,22 @@ class HistoryContainerController extends BaseController {
     }
     return result;
   };
+
+  deletePayment = async (paymentId) => {
+    const result = await this.userModel.deletePayment(paymentId);
+    if (!result.success) {
+      const { error } = result;
+      if (error.errorType === errorTypes.NotExist) {
+        return { success: false, message: '삭제에 실패했습니다!' };
+      } else {
+        return {
+          success: false,
+          message: '예끼치 못한 에러가 발생하였습니다!',
+        };
+      }
+    }
+    return result;
+  };
 }
 
 export default new HistoryContainerController();

--- a/frontend/src/views/components/historyContainer/controller.js
+++ b/frontend/src/views/components/historyContainer/controller.js
@@ -111,6 +111,21 @@ class HistoryContainerController extends BaseController {
     }
     return result;
   };
+  updatePayment = async ({ paymentId, name }) => {
+    const result = await this.userModel.updatePayment({ paymentId, name });
+    if (!result.success) {
+      const { error } = result;
+      if (error.errorType === errorTypes.NotExist) {
+        return { success: false, message: '존재하지 않는 결제정보입니다!' };
+      } else {
+        return {
+          success: false,
+          message: '예끼치 못한 에러가 발생하였습니다!',
+        };
+      }
+    }
+    return result;
+  };
 }
 
 export default new HistoryContainerController();

--- a/frontend/src/views/components/historyContainer/controller.js
+++ b/frontend/src/views/components/historyContainer/controller.js
@@ -1,6 +1,8 @@
 import BaseController from '@/common/utils/baseController';
 import notifyTypes from '@/common/utils/notifyTypes';
 
+import errorTypes from '@/common/utils/error';
+
 const initalIncludeOptions = {
   income: true,
   expenditure: true,
@@ -72,6 +74,26 @@ class HistoryContainerController extends BaseController {
   setAccountIncludeOptions = (accountsIncludeOptions) => {
     this.accountsIncludeOptions = accountsIncludeOptions;
     this.observer.notify(notifyTypes.CHANGED_DATA_FILTER);
+  };
+
+  getPayments = () => {
+    return this.userModel.getPayments();
+  };
+
+  addPayment = async (name) => {
+    const result = await this.userModel.addPayment(name);
+    if (!result.success) {
+      const { error } = result;
+      if (error.errorType === errorTypes.AlreadyExist) {
+        return { success: false, message: '이미 같은 결제수단이 존재합니다!' };
+      } else {
+        return {
+          success: false,
+          message: '예끼치 못한 에러가 발생하였습니다!',
+        };
+      }
+    }
+    return result;
   };
 }
 

--- a/frontend/src/views/components/historyContainer/editPayment.js
+++ b/frontend/src/views/components/historyContainer/editPayment.js
@@ -7,11 +7,14 @@ import historyContainerController from './controller';
 import './style.css';
 import notifyTypes from '@/common/utils/notifyTypes';
 
-class AddPayment extends HTMLElement {
-  constructor() {
+class EditPayment extends HTMLElement {
+  constructor({ paymentId }) {
     super();
     this.controller = historyContainerController;
     this.observer = observer;
+
+    const payments = this.controller.getPayments();
+    this.payment = payments.find((p) => p.id === paymentId);
   }
 
   connectedCallback() {
@@ -20,25 +23,37 @@ class AddPayment extends HTMLElement {
 
   addEvents = () => {
     const $form = this.querySelector('#add-payment-form');
-    const $cancelBtn = this.querySelector('#cancel-btn');
+    const $deleteBtn = this.querySelector('#delete-btn');
 
     $form.addEventListener('submit', this.handleSubmit);
-    $cancelBtn.addEventListener('click', () => {
-      this.observer.notify(notifyTypes.CLOSE_MODAL);
-    });
+    $deleteBtn.addEventListener('click', this.handleDelete);
   };
 
   handleSubmit = async (event) => {
     event.preventDefault();
     const $payment = event.currentTarget.querySelector('#payment-input');
     const name = $payment.value;
-    const result = await this.controller.addPayment(name);
+    const result = await this.controller.updatePayment(name);
     if (!result.success) {
       this.displayResultMessage(result.message, result.success);
       return;
     }
-    this.displayResultMessage('결제정보를 추가했습니다!', result.success);
+    this.displayResultMessage('결제정보를 수정했습니다!', result.success);
   };
+
+  handleDelete = async () => {
+    const result = await this.controller.deletePayment(this.payment.id);
+    if (!result.success) {
+      this.displayResultMessage(result.message, result.success);
+      return;
+    }
+
+    this.displayResultMessage('결제정보가 삭제되었습니다!', result.success);
+    setTimeout(() => {
+      this.observer.notify(notifyTypes.CLOSE_MODAL);
+    }, 1200);
+  };
+
   displayResultMessage = (message, success) => {
     const $addForm = this.querySelector('#add-payment-form');
     const $errorText = $addForm.parentNode.querySelector('.error-text');
@@ -48,33 +63,34 @@ class AddPayment extends HTMLElement {
     }
     $errorText.style.display = 'block';
   };
+
   render = () => {
     this.setHTML(
       /*html*/ ` 
       <form id='add-payment-form'>
         <div class="top">
             <label>
-                추가하실 결제수단을 적어주세요.
+                새 결제수단을 입력하세요.
             </label>
-            <input type='text' id='payment-input' placeholder="입력하세요"/>
+            <input type='text' id='payment-input' placeholder='${this.payment.name}'/>
         </div>
         <span class="error-text"></span>
         <div class='bottom'>
             <div class='left'>
-                <button id='cancel-btn' type='button'>취소</button>
+                <button id='delete-btn' type='button'>삭제</button>
             </div>
             <div>
-                <button id='submit-btn' type='submit'>등록</button>
+                <button id='submit-btn' type='submit'>수정</button>
             </div>
         </div>
     </form>
     `
-    ).addClass('add-payment');
+    ).addClass('edit-payment');
 
     this.addEvents();
   };
 }
 
-customElements.define('add-payment', AddPayment);
+customElements.define('edit-payment', EditPayment);
 
-export default customElements.get('add-payment');
+export default customElements.get('edit-payment');

--- a/frontend/src/views/components/historyContainer/editPayment.js
+++ b/frontend/src/views/components/historyContainer/editPayment.js
@@ -12,14 +12,19 @@ class EditPayment extends HTMLElement {
     super();
     this.controller = historyContainerController;
     this.observer = observer;
-
-    const payments = this.controller.getPayments();
-    this.payment = payments.find((p) => p.id === paymentId);
+    this.payment = null;
+    this.paymentId = paymentId;
+    this.setPayment(paymentId);
   }
 
   connectedCallback() {
     this.render();
   }
+
+  setPayment = (paymentId) => {
+    const payments = this.controller.getPayments();
+    this.payment = payments.find((p) => p.id === paymentId);
+  };
 
   addEvents = () => {
     const $form = this.querySelector('#add-payment-form');
@@ -33,11 +38,16 @@ class EditPayment extends HTMLElement {
     event.preventDefault();
     const $payment = event.currentTarget.querySelector('#payment-input');
     const name = $payment.value;
-    const result = await this.controller.updatePayment(name);
+    const result = await this.controller.updatePayment({
+      paymentId: this.paymentId,
+      name,
+    });
     if (!result.success) {
       this.displayResultMessage(result.message, result.success);
       return;
     }
+    this.setPayment(this.paymentId);
+    this.render();
     this.displayResultMessage('결제정보를 수정했습니다!', result.success);
   };
 

--- a/frontend/src/views/components/historyContainer/historyPanel.js
+++ b/frontend/src/views/components/historyContainer/historyPanel.js
@@ -30,6 +30,7 @@ class HistoryPanel extends HTMLElement {
     this.currentDate = this.currentDate.getDate();
 
     this.payments = this.controller.getPayments();
+    this.selectedPaymentId = null;
 
     this.dateString = parsingDate(new Date());
   }
@@ -43,6 +44,11 @@ class HistoryPanel extends HTMLElement {
     this.observer.subscribe(notifyTypes.INIT_USER, this, this.handleInitUser);
 
     this.render();
+  }
+
+  disconnectedCallback() {
+    this.observer.unsubscribe(notifyTypes.CLICK_ACCOUNT, this);
+    this.observer.unsubscribe(notifyTypes.INIT_USER, this);
   }
 
   handleAccountClick = (accountInfo) => {
@@ -89,13 +95,17 @@ class HistoryPanel extends HTMLElement {
   selectPayment = (id) => {
     this.togglePaymentDropdown();
     const $selectPaymentBtn = this.querySelector('#select-payment-btn');
-    $selectPaymentBtn.innerHTML = `${this.payments[id]} ${chevronDown}`;
+    this.selectedPaymentId = Number(id);
+    const payment = this.payments.find((p) => p.id === this.selectedPaymentId);
+    $selectPaymentBtn.innerHTML = `${payment.name} ${chevronDown}`;
     $selectPaymentBtn.classList.add('selected');
   };
 
   handleAddPayment = () => {
     this.observer.notify(notifyTypes.CLICK_ADD_PAYMENT);
   };
+
+  handleModifyPayment;
 
   addEvents = () => {
     const $selectCategoryBtn = this.querySelector('#select-category-btn');
@@ -118,6 +128,9 @@ class HistoryPanel extends HTMLElement {
     $paymentDropdown.addEventListener('click', ({ target }) => {
       if (target.id === 'add-payment') {
         this.handleAddPayment();
+        return;
+      } else if (target.id === 'edit') {
+        this.handleModifyPayment();
         return;
       }
       this.selectPayment(target.dataset.id);
@@ -174,7 +187,10 @@ class HistoryPanel extends HTMLElement {
                           return `
                               <div class='payment-item' data-id=${payment.id}>
                                   <div class='content'>
-                                    ${payment.name} ${verticalMore}
+                                    ${payment.name} 
+                                  </div>
+                                  <div class='edit' id='edit' data-id=${payment.id}>
+                                    ${verticalMore}
                                   </div>
                               </div>
                             `;

--- a/frontend/src/views/components/historyContainer/historyPanel.js
+++ b/frontend/src/views/components/historyContainer/historyPanel.js
@@ -105,7 +105,9 @@ class HistoryPanel extends HTMLElement {
     this.observer.notify(notifyTypes.CLICK_ADD_PAYMENT);
   };
 
-  handleModifyPayment;
+  handleModifyPayment = (id) => {
+    this.observer.notify(notifyTypes.CLICK_EDIT_PAYMENT, Number(id));
+  };
 
   addEvents = () => {
     const $selectCategoryBtn = this.querySelector('#select-category-btn');
@@ -130,7 +132,7 @@ class HistoryPanel extends HTMLElement {
         this.handleAddPayment();
         return;
       } else if (target.id === 'edit') {
-        this.handleModifyPayment();
+        this.handleModifyPayment(target.dataset.id);
         return;
       }
       this.selectPayment(target.dataset.id);

--- a/frontend/src/views/components/historyContainer/historyPanel.js
+++ b/frontend/src/views/components/historyContainer/historyPanel.js
@@ -1,6 +1,6 @@
 import observer from '@/common/utils/observer';
 import notifyTypes from '@/common/utils/notifyTypes';
-import { check, chevronDown, iconButton } from '../icons';
+import { check, chevronDown, iconButton, verticalMore } from '../icons';
 import historyContainerController from './controller';
 import { parsingDate } from '@/common/utils/functions';
 
@@ -17,8 +17,6 @@ const categories = [
   '미분류',
 ];
 
-const payments = ['현대카드', '삼성카드'];
-
 class HistoryPanel extends HTMLElement {
   constructor() {
     super();
@@ -31,6 +29,8 @@ class HistoryPanel extends HTMLElement {
     this.currentMonth = this.currentDate.getMonth() + 1;
     this.currentDate = this.currentDate.getDate();
 
+    this.payments = this.controller.getPayments();
+
     this.dateString = parsingDate(new Date());
   }
 
@@ -40,6 +40,7 @@ class HistoryPanel extends HTMLElement {
       this,
       this.handleAccountClick
     );
+    this.observer.subscribe(notifyTypes.INIT_USER, this, this.handleInitUser);
 
     this.render();
   }
@@ -52,6 +53,11 @@ class HistoryPanel extends HTMLElement {
     this.paymentMethod = paymentMethod;
     this.price = price;
 
+    this.render();
+  };
+
+  handleInitUser = () => {
+    this.payments = this.controller.getPayments();
     this.render();
   };
 
@@ -83,8 +89,12 @@ class HistoryPanel extends HTMLElement {
   selectPayment = (id) => {
     this.togglePaymentDropdown();
     const $selectPaymentBtn = this.querySelector('#select-payment-btn');
-    $selectPaymentBtn.innerHTML = `${payments[id]} ${chevronDown}`;
+    $selectPaymentBtn.innerHTML = `${this.payments[id]} ${chevronDown}`;
     $selectPaymentBtn.classList.add('selected');
+  };
+
+  handleAddPayment = () => {
+    this.observer.notify(notifyTypes.CLICK_ADD_PAYMENT);
   };
 
   addEvents = () => {
@@ -106,6 +116,10 @@ class HistoryPanel extends HTMLElement {
     });
     const $paymentDropdown = this.querySelector('.dropdown.payment');
     $paymentDropdown.addEventListener('click', ({ target }) => {
+      if (target.id === 'add-payment') {
+        this.handleAddPayment();
+        return;
+      }
       this.selectPayment(target.dataset.id);
     });
   };
@@ -155,19 +169,22 @@ class HistoryPanel extends HTMLElement {
                 <label>결제수단</label>
                 <button id="select-payment-btn">선택하세요 ${chevronDown}</button>
                 <div class="dropdown payment">
-                      ${payments
-                        .map((payment, index) => {
-                          return (
-                            '<div class="payment-item" data-id=' +
-                            index +
-                            '>' +
-                            '<div class="content">' +
-                            payment +
-                            '</div>' +
-                            '</div>'
-                          );
+                      ${this.payments
+                        .map((payment) => {
+                          return `
+                              <div class='payment-item' data-id=${payment.id}>
+                                  <div class='content'>
+                                    ${payment.name} ${verticalMore}
+                                  </div>
+                              </div>
+                            `;
                         })
                         .join('')}
+                        <div id="add-payment">
+                          <div class="content">
+                            추가하기
+                          </div>
+                        </div>
                     </div>
             </div>
 

--- a/frontend/src/views/components/historyContainer/index.js
+++ b/frontend/src/views/components/historyContainer/index.js
@@ -3,6 +3,7 @@ import HistoryContent from './historyContent'; // this can use history-content t
 import historyStatistics from './historyStatistics';
 import Modal from '../modal';
 import AddPayment from './addPayment';
+import EditPayment from './editPayment';
 
 import observer from '@/common/utils/observer';
 import historyContainerController from './controller';
@@ -30,16 +31,26 @@ class HistoryContainer extends HTMLElement {
       this,
       this.showAddPayment
     );
+    this.observer.subscribe(
+      notifyTypes.CLICK_EDIT_PAYMENT,
+      this,
+      this.showEditPayment
+    );
   }
 
+  showEditPayment = (paymentId) => {
+    this.showModalContent(this.modalType.EDIT_PAYMENT, { paymentId });
+  };
   showAddPayment = () => {
     this.showModalContent(this.modalType.ADD_PAYMENT);
   };
 
-  showModalContent = (type) => {
+  showModalContent = (type, data = {}) => {
     let $currentContent;
     if (type === this.modalType.ADD_PAYMENT) {
-      $currentContent = new AddPayment();
+      $currentContent = new AddPayment(data);
+    } else if (type === this.modalType.EDIT_PAYMENT) {
+      $currentContent = new EditPayment(data);
     }
     const $addPaymentModal = new Modal({
       $contentElement: $currentContent,

--- a/frontend/src/views/components/historyContainer/index.js
+++ b/frontend/src/views/components/historyContainer/index.js
@@ -1,21 +1,52 @@
 import HistoryPanel from './historyPanel'; // this can use history-statistics tag in inner html
 import HistoryContent from './historyContent'; // this can use history-content tag in inner html
 import historyStatistics from './historyStatistics';
+import Modal from '../modal';
+import AddPayment from './addPayment';
 
+import observer from '@/common/utils/observer';
 import historyContainerController from './controller';
 
 import './style.css';
+import notifyTypes from '@/common/utils/notifyTypes';
 
 class HistoryContainer extends HTMLElement {
   constructor() {
     super();
     this.controller = historyContainerController;
+    this.observer = observer;
     this.controller.init();
+
+    this.modalType = {
+      ADD_PAYMENT: 'add-payment',
+      EDIT_PAYMENT: 'edit-payment',
+    };
   }
 
   connectedCallback() {
     this.render();
+    this.observer.subscribe(
+      notifyTypes.CLICK_ADD_PAYMENT,
+      this,
+      this.showAddPayment
+    );
   }
+
+  showAddPayment = () => {
+    this.showModalContent(this.modalType.ADD_PAYMENT);
+  };
+
+  showModalContent = (type) => {
+    let $currentContent;
+    if (type === this.modalType.ADD_PAYMENT) {
+      $currentContent = new AddPayment();
+    }
+    const $addPaymentModal = new Modal({
+      $contentElement: $currentContent,
+    });
+
+    this.appendChild($addPaymentModal);
+  };
 
   render = () => {
     this.setHTML(

--- a/frontend/src/views/components/historyContainer/style.css
+++ b/frontend/src/views/components/historyContainer/style.css
@@ -228,7 +228,8 @@ history-statistics .right > div {
   cursor: pointer;
 }
 
-add-payment {
+add-payment,
+edit-payment {
   display: flex;
   flex-direction: column;
   min-width: 350px;
@@ -239,18 +240,21 @@ add-payment {
   border-radius: 10px;
 }
 
-add-payment .top {
+add-payment .top,
+edit-payment .top {
   display: flex;
   flex-direction: column;
   width: 100%;
 }
 
-add-payment .top label {
+add-payment .top label,
+edit-payment .top label {
   font: var(--body-medium);
   color: var(--title-active);
 }
 
-add-payment .top input {
+add-payment .top input,
+edit-payment .top input {
   margin-top: 24px;
   background: var(--background);
   border: 1px solid var(--line);
@@ -262,17 +266,20 @@ add-payment .top input {
   outline: none;
 }
 
-add-payment .bottom {
+add-payment .bottom,
+edit-payment .bottom {
   display: flex;
   justify-content: space-between;
   width: 100%;
   margin-top: 40px;
 }
 
-add-payment .bottom button {
+add-payment .bottom button,
+edit-payment .bottom button {
   font: var(--body-medium);
 }
 
-add-payment .bottom #submit-btn {
+add-payment .bottom #submit-btn,
+edit-payment .bottom #submit-btn {
   color: var(--primary3);
 }

--- a/frontend/src/views/components/historyContainer/style.css
+++ b/frontend/src/views/components/historyContainer/style.css
@@ -123,8 +123,22 @@ history-panel .dropdown .content {
   justify-content: space-between;
 }
 
+history-panel .dropdown .payment-item {
+  position: relative;
+}
+
+history-panel .dropdown #edit {
+  position: absolute;
+  right: 14px;
+}
+
+history-panel .dropdown #edit svg {
+  pointer-events: none;
+}
+
 history-panel .dropdown .content svg {
   height: 20px;
+  width: 20px;
 }
 
 history-panel .dropdown > :last-child .content {

--- a/frontend/src/views/components/historyContainer/style.css
+++ b/frontend/src/views/components/historyContainer/style.css
@@ -283,3 +283,7 @@ add-payment .bottom #submit-btn,
 edit-payment .bottom #submit-btn {
   color: var(--primary3);
 }
+
+edit-payment .bottom #delete-btn {
+  color: var(--error);
+}

--- a/frontend/src/views/components/historyContainer/style.css
+++ b/frontend/src/views/components/historyContainer/style.css
@@ -118,9 +118,13 @@ history-panel .dropdown .content {
   width: 100px;
   height: 100%;
   display: flex;
-  justify-content: center;
   align-items: center;
   pointer-events: none;
+  justify-content: space-between;
+}
+
+history-panel .dropdown .content svg {
+  height: 20px;
 }
 
 history-panel .dropdown > :last-child .content {
@@ -208,4 +212,53 @@ history-statistics .right > div {
   justify-content: center;
   align-items: center;
   cursor: pointer;
+}
+
+add-payment {
+  display: flex;
+  flex-direction: column;
+  min-width: 350px;
+  background-color: var(--background);
+  justify-content: center;
+  align-items: center;
+  padding: 40px;
+  border-radius: 10px;
+}
+
+add-payment .top {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+add-payment .top label {
+  font: var(--body-medium);
+  color: var(--title-active);
+}
+
+add-payment .top input {
+  margin-top: 24px;
+  background: var(--background);
+  border: 1px solid var(--line);
+  width: 100%;
+  height: 42px;
+  border-radius: 10px;
+  padding: 10px;
+  font: var(--body-medium);
+  outline: none;
+}
+
+add-payment .bottom {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  margin-top: 40px;
+}
+
+add-payment .bottom button {
+  font: var(--body-medium);
+}
+
+add-payment .bottom #submit-btn {
+  color: var(--primary3);
 }

--- a/frontend/src/views/components/icons/index.js
+++ b/frontend/src/views/components/icons/index.js
@@ -93,5 +93,12 @@ export const logoutButton = /*html*/ `
 <path d="M16 17L21 12L16 7" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M21 12H9" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>
+`;
 
+export const verticalMore = /*html*/ `
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 13C12.5523 13 13 12.5523 13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12C11 12.5523 11.4477 13 12 13Z" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 6C12.5523 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5C11 5.55228 11.4477 6 12 6Z" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 20C12.5523 20 13 19.5523 13 19C13 18.4477 12.5523 18 12 18C11.4477 18 11 18.4477 11 19C11 19.5523 11.4477 20 12 20Z" stroke="#222222" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>
 `;

--- a/frontend/src/views/components/modal/index.js
+++ b/frontend/src/views/components/modal/index.js
@@ -1,19 +1,43 @@
+import notifyTypes from '@/common/utils/notifyTypes';
+import observer from '@/common/utils/observer';
 import './style.css';
 
 class Modal extends HTMLElement {
-  constructor({ $contentElement }) {
+  constructor({ $contentElement, toggleModal = true }) {
     super();
     this.$contentElement = $contentElement;
+    this.toggleModal = toggleModal;
+    this.observer = observer;
   }
 
   connectedCallback() {
+    this.observer.subscribe(notifyTypes.CLOSE_MODAL, this, this.closeModal);
     this.render();
   }
+
+  addEvents = () => {
+    this.addEventListener('click', ({ target }) => {
+      if (target === this) {
+        this.handleModalClick();
+      }
+    });
+  };
+
+  handleModalClick = () => {
+    if (this.toggleModal) {
+      this.closeModal();
+    }
+  };
+  closeModal = () => {
+    this.remove();
+  };
 
   render = () => {
     this.setHTML(/*html*/ ``);
 
     this.appendChild(this.$contentElement);
+
+    this.addEvents();
   };
 }
 

--- a/frontend/src/views/components/modal/style.css
+++ b/frontend/src/views/components/modal/style.css
@@ -1,7 +1,7 @@
 modal-view {
   background-color: rgba(0, 0, 0, 0.4);
   display: flex;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100vw;


### PR DESCRIPTION
#30 

## 개요
  - 프론트엔드에서 payment를 CRUD 할 수 있습니다.

## 변경사항
  - 프론트엔드에 paymentAPI를 만들었습니다.
  - 모달 컴포넌트에 toggleModal 옵션을 두어 배경을 클릭시 모달이


<img width="468" alt="스크린샷 2021-08-05 오전 12 24 42" src="https://user-images.githubusercontent.com/47034129/128208472-3268f8c2-1e06-46e5-a6e7-0702b4f3e461.png">

<img width="457" alt="스크린샷 2021-08-05 오전 12 24 56" src="https://user-images.githubusercontent.com/47034129/128208512-9a932ffd-35f6-458e-b67e-2490fac40099.png">
